### PR TITLE
Fix script name in README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The VirusTotal Lookup is a Python script that extracts and filters MD5, SHA1, SH
 
 2. Run the script:
     ```sh
-    python VirusTotalLookup.py
+    python VirusTotal_lookup.py
     ```
 
 3. Follow the prompts to select the entity types you want to query.


### PR DESCRIPTION
## Summary
- use the correct filename `VirusTotal_lookup.py` in the README usage section

## Testing
- `python -m py_compile VirusTotal_lookup.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e01cd69c8333958bc25220505c57